### PR TITLE
Force dynamic rendering for the (root) route group

### DIFF
--- a/app/(root)/layout.tsx
+++ b/app/(root)/layout.tsx
@@ -7,6 +7,10 @@ import { getCurrentUser } from '@/lib/action/user.actions'
 import { redirect } from 'next/navigation'
 import React from 'react'
 
+// Every page in this group reads the `appwrite-session` cookie, so none of them
+// can be prerendered at build time.
+export const dynamic = 'force-dynamic'
+
 const Layout = async ({ children }: { children: React.ReactNode }) => {
     let currentUser = null;
     try {

--- a/app/(root)/page.tsx
+++ b/app/(root)/page.tsx
@@ -4,8 +4,6 @@ import { calculatePercentage, convertFileSize } from "@/lib/utils";
 import Image from "next/image";
 import { PieChart } from "@mui/x-charts/PieChart";
 
-export const dynamic = "force-dynamic"; // optional if you want to disable caching
-
 type FileCategory = "documents" | "images" | "media" | "others";
 
 export default async function Home() {


### PR DESCRIPTION
/profile was being statically prerendered at build time and baked in a permanent "User not found. Please sign in." page.

Root cause: getCurrentUser() -> createSessionClient() calls cookies(). At build time cookies() throws DYNAMIC_SERVER_USAGE, which is Next's signal that a route cannot be prerendered. The try/catch in getCurrentUser() swallowed that error and returned null, so Next never saw the signal, prerendered /profile anyway, and served the null-user branch as static HTML to every visitor. The build did not fail, which is why this shipped unnoticed.

Set `export const dynamic = 'force-dynamic'` on the (root) layout rather than on the page, since every route in the group reads the appwrite-session cookie and would hit the same trap. Drops the now redundant per-page declaration in page.tsx.

Build output confirms: /profile is now ƒ (dynamic) instead of ○ (static).