### PR TITLE
Fix no-op URL reset and debounce bypass in Search

### DIFF
--- a/components/FileUploader.tsx
+++ b/components/FileUploader.tsx
@@ -56,7 +56,7 @@ const FileUploader = ({ ownerId, accountId, className }: Props) => {
     });
 
     await Promise.all(uploadPromises);
-  }, [ownerId, accountId, path]);
+  }, [ownerId, accountId, path, toast]);
 
   const { getRootProps, getInputProps } = useDropzone({ onDrop })
 

--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -31,16 +31,16 @@ const Search = () => {
       if (debounceQuery.length === 0) {
         setResults([])
         setOpen(false)
-        return router.push(path.replace(searchParams.toString(), ''))
+        return router.push(path)
       }
 
-      const files = await getFiles({ types: [], searchText: query })
+      const files = await getFiles({ types: [], searchText: debounceQuery })
 
       setResults(files.documents)
       setOpen(true)
     }
     fetchFile()
-  }, [debounceQuery])
+  }, [debounceQuery, path, router])
 
   const handleClickItem = (file: Models.Document) => {
     setOpen(false)


### PR DESCRIPTION
Two bugs surfaced by the react-hooks/exhaustive-deps warnings:

- `path.replace(searchParams.toString(), '')` was dead code. `path` comes from usePathname() and contains only the pathname, never the query string, so the replace never matched and the URL was pushed unchanged. Clearing the search box therefore left ?query= in the URL. Use `router.push(path)`.

- The effect fires on `debounceQuery` but searched with the raw `query`, partially defeating the 1s debounce. Search with `debounceQuery`.

Deps arrays now match what the callbacks actually close over. `toast` is stable in shadcn's useToast, so adding it to FileUploader's useCallback is a no-op that just silences the lint. Build is warning-free.